### PR TITLE
fixed bug: can't scroll rom list with zh_CN pack

### DIFF
--- a/src/sdl-dingux/gui_main.cpp
+++ b/src/sdl-dingux/gui_main.cpp
@@ -2007,7 +2007,8 @@ pagedown:
 						sel.ofs = 0;
 					} else {
 movedown:
-						if (romlist.nb_list[cfg.list] < 14) { // if rom number in list < 14
+						if (romlist.nb_list[cfg.list] <= gui_lang.gamelist_line_count + 1) {
+							// if rom number in list <= gui_lang.gamelist_line_count + 1
 								if (sel.rom < romlist.nb_list[cfg.list] - 1) {
 									sel.y += gui_lang.gamelist_line_height;
 									++sel.rom;


### PR DESCRIPTION
修复bug：使用汉化包后，如果前端rom列表数量小于14并且大于1页可显示数量的话，该rom列表不会向下滚动。