### PR TITLE
fixed bug: base number of scrolling rom list error

### DIFF
--- a/src/sdl-dingux/gui_main.cpp
+++ b/src/sdl-dingux/gui_main.cpp
@@ -2007,8 +2007,8 @@ pagedown:
 						sel.ofs = 0;
 					} else {
 movedown:
-						if (romlist.nb_list[cfg.list] <= gui_lang.gamelist_line_count + 1) {
-							// if rom number in list <= gui_lang.gamelist_line_count + 1
+						if (romlist.nb_list[cfg.list] <= gui_lang.gamelist_line_count) {
+							// if rom number in list <= gui_lang.gamelist_line_count
 								if (sel.rom < romlist.nb_list[cfg.list] - 1) {
 									sel.y += gui_lang.gamelist_line_height;
 									++sel.rom;


### PR DESCRIPTION
I find the base number of scrolling rom list of original sdl-dingux is wrong after simply testing.