### PR TITLE
Reloads game defaults once game selected using command line

### DIFF
--- a/src/sdl-dingux/main.cpp
+++ b/src/sdl-dingux/main.cpp
@@ -278,10 +278,12 @@ int main(int argc, char **argv )
 		GuiRun();
 	else {
 		int drv;
-
-		if((drv = FindDrvByFileName(path)) >= 0)
+		if((drv = FindDrvByFileName(path)) >= 0) {
+            // Reloads game defaults once game selected using command line
+			ConfigGameDefault();
 			RunEmulator(drv);
-	}
+        }
+    }
 
 	BurnLibExit();
 


### PR DESCRIPTION
The current fba .44 ignores game options when started from command line.

This fix reloads game defaults once game is selected using command line.
It permits to play -180 degrees vertical game rotation from SimpleMenu or any launcher.

Fixes #11 