### PR TITLE
Reloads game defaults once game selected using command line

### DIFF
--- a/src/sdl-dingux/main.cpp
+++ b/src/sdl-dingux/main.cpp
@@ -279,8 +279,8 @@ int main(int argc, char **argv )
 	else {
 		int drv;
 		if((drv = FindDrvByFileName(path)) >= 0) {
-            // Reloads game defaults once game selected using command line
-			ConfigGameDefault();
+            // Loads game config once game selected using command line
+			ConfigGameLoad();
 			RunEmulator(drv);
         }
     }

--- a/src/sdl-dingux/main.cpp
+++ b/src/sdl-dingux/main.cpp
@@ -278,10 +278,12 @@ int main(int argc, char **argv )
 		GuiRun();
 	else {
 		int drv;
-
-		if((drv = FindDrvByFileName(path)) >= 0)
+		if((drv = FindDrvByFileName(path)) >= 0) {
+            // Reloads game defaults once game selected using command line
+			ConfigGameDefault();
 			RunEmulator(drv);
-	}
+        }
+    }
 
 	BurnLibExit();
 


### PR DESCRIPTION
The current fba .44 ignores game options when started from command line.

This fix loads game defaults once game is selected using command line.
It permits to play -180 degrees vertical game rotation from SimpleMenu or any launcher.

Fixes #13 

Release with this fix is available here for test purpose : https://github.com/goldmojo/fba-sdl/releases/tag/r19_2020-01-29-.44_alias_cmdline_gameconfig