### PR TITLE
Reactivate some missing inputs (chase hq, outrun, etc.)

### DIFF
--- a/src/sdl-dingux/input.cpp
+++ b/src/sdl-dingux/input.cpp
@@ -355,7 +355,6 @@ int InpMake(unsigned int key[])
 					{
 						if (down) *(GameInput[joyNum][i].pVal)=0xff; else *(GameInput[joyNum][i].pVal)=0x01;
 					}
-#if 0
 					if (i==12) //analogue x
 					{
 						nJoy=SDL_JoystickGetAxis(joys[joyNum],0) << 1;
@@ -436,7 +435,6 @@ int InpMake(unsigned int key[])
 						}
 						*(GameInput[joyNum][i].pShortVal)=nJoy;
 					}
-#endif
 				}
 				else
 				{


### PR DESCRIPTION
Since r7, driving games control don't work any more.

This fix reactivate controls that had been deactivated in r7.

Fixes #5 

Release with this fix is available here for test purpose : https://github.com/goldmojo/fba-sdl/releases/tag/r19_2020-01-29-.44_alias_cmdline_gameconfig_controls